### PR TITLE
UI fixes for issue #4

### DIFF
--- a/CHANGELOG/v2_9_1.md
+++ b/CHANGELOG/v2_9_1.md
@@ -2,10 +2,17 @@
 
 # Summary of the changes
 
--> Added a new function cap_label_length to the inodeinfo.h/inodeinfo.c module for determining printable length of labels based on current window width.
+-> Added a new function cap_label_length to the inodeinfo.h/inodeinfo.c module for determining printable length of labels based on current window width or fixed max length, whichever is
+more restrictive.
 
 -> Restricted the length of current directory, parent, and child
 inodes, as well as the file name field in the file info window, 
 to prevent overrun onto the next line.
 
--> Restricted the file name field in the file info window
+-> Add single quotes to the unzip/7z/tar commands to prevent issues with filenames containing spaces in filepreview module.
+
+-> Modified the process of truncating strings and adding ellipses ("...") for the following labels:
+    - Filename in selected file info window at top right.
+    - Filenames in current dir. in left window.
+    - Parent directories at bottom right in info window.
+    - Child inodes at bottom right in info window.

--- a/CHANGELOG/v2_9_1.md
+++ b/CHANGELOG/v2_9_1.md
@@ -1,0 +1,11 @@
+# Change Type:Minor
+
+# Summary of the changes
+
+-> Added a new function cap_label_length to the inodeinfo.h/inodeinfo.c module for determining printable length of labels based on current window width.
+
+-> Restricted the length of current directory, parent, and child
+inodes, as well as the file name field in the file info window, 
+to prevent overrun onto the next line.
+
+-> Restricted the file name field in the file info window

--- a/include/inodeinfo.h
+++ b/include/inodeinfo.h
@@ -37,6 +37,7 @@
 
 #define MAX_ITEM_NAME_LENGTH 80
 
+int cap_label_length(unsigned int len, unsigned int quarter, unsigned int margin);
 void get_file_info_popup(WINDOW* main_win, const char* path, const char* filename);
 void get_file_info(WINDOW* info_win, const char* path, const char* filename);
 void truncate_symlink_name(char* name);

--- a/lfm.c
+++ b/lfm.c
@@ -313,13 +313,17 @@ void print_items(WINDOW* win, FileItem items[], int count, int highlight, const 
 
       // Truncate the item name if it exceeds MAX_ITEM_NAME_LENGTH
       char truncated_name[MAX_ITEM_NAME_LENGTH + 4]; // +4 for ellipsis and space
+      int length_cap = sizeof(truncated_name);
+      if (length_cap > ((COLS / 2) - 10)) {
+        length_cap = ((COLS / 2) - 10);
+      }
       if (strlen(items[index].name) > MAX_ITEM_NAME_LENGTH)
       {
-        snprintf(truncated_name, sizeof(truncated_name), "%.40s...", items[index].name);
+        snprintf(truncated_name, length_cap, "%.40s...", items[index].name);
       }
       else
       {
-        snprintf(truncated_name, sizeof(truncated_name), "%s", items[index].name);
+        snprintf(truncated_name, length_cap, "%s", items[index].name);
       }
 
       wattron(win, A_BOLD);

--- a/lfm.c
+++ b/lfm.c
@@ -314,12 +314,13 @@ void print_items(WINDOW* win, FileItem items[], int count, int highlight, const 
       // Truncate the item name if it exceeds MAX_ITEM_NAME_LENGTH
       char truncated_name[MAX_ITEM_NAME_LENGTH + 4]; // +4 for ellipsis and space
       int printable_length = cap_label_length(sizeof(truncated_name), 0, 10);
-      if (strlen(items[index].name) > MAX_ITEM_NAME_LENGTH)
-      {
-        snprintf(truncated_name, printable_length, "%.40s...", items[index].name);
-      }
-      else
-      {
+
+      if (strlen(items[index].name) > printable_length - 3) {
+        snprintf(truncated_name, printable_length - 3, "%s", items[index].name);
+        // why does the param need 6 subtracted from it? found by trial and error,
+        // but do not really understand how the "math is mathing".
+        snprintf(truncated_name + (printable_length - 6), 4, "...");
+      } else {
         snprintf(truncated_name, printable_length, "%s", items[index].name);
       }
 

--- a/lfm.c
+++ b/lfm.c
@@ -313,10 +313,7 @@ void print_items(WINDOW* win, FileItem items[], int count, int highlight, const 
 
       // Truncate the item name if it exceeds MAX_ITEM_NAME_LENGTH
       char truncated_name[MAX_ITEM_NAME_LENGTH + 4]; // +4 for ellipsis and space
-      int printable_length = sizeof(truncated_name);
-      if (printable_length > ((COLS / 2) - 10)) {
-        printable_length = ((COLS / 2) - 10);
-      }
+      int printable_length = cap_label_length(sizeof(truncated_name), 0, 10);
       if (strlen(items[index].name) > MAX_ITEM_NAME_LENGTH)
       {
         snprintf(truncated_name, printable_length, "%.40s...", items[index].name);

--- a/lfm.c
+++ b/lfm.c
@@ -313,17 +313,17 @@ void print_items(WINDOW* win, FileItem items[], int count, int highlight, const 
 
       // Truncate the item name if it exceeds MAX_ITEM_NAME_LENGTH
       char truncated_name[MAX_ITEM_NAME_LENGTH + 4]; // +4 for ellipsis and space
-      int length_cap = sizeof(truncated_name);
-      if (length_cap > ((COLS / 2) - 10)) {
-        length_cap = ((COLS / 2) - 10);
+      int printable_length = sizeof(truncated_name);
+      if (printable_length > ((COLS / 2) - 10)) {
+        printable_length = ((COLS / 2) - 10);
       }
       if (strlen(items[index].name) > MAX_ITEM_NAME_LENGTH)
       {
-        snprintf(truncated_name, length_cap, "%.40s...", items[index].name);
+        snprintf(truncated_name, printable_length, "%.40s...", items[index].name);
       }
       else
       {
-        snprintf(truncated_name, length_cap, "%s", items[index].name);
+        snprintf(truncated_name, printable_length, "%s", items[index].name);
       }
 
       wattron(win, A_BOLD);

--- a/src/filepreview.c
+++ b/src/filepreview.c
@@ -585,15 +585,15 @@ void display_archive_contents(WINDOW* info_win, const char* full_path, const cha
   char* cmd;
   if (strcmp(file_ext, ".zip") == 0)
   {
-    asprintf(&cmd, "unzip -l %s/%s", dir_name, file_name);
+    asprintf(&cmd, "unzip -l '%s/%s'", dir_name, file_name);
   }
   else if (strcmp(file_ext, ".7z") == 0)
   {
-    asprintf(&cmd, "7z l %s/%s", dir_name, file_name);
+    asprintf(&cmd, "7z l '%s/%s'", dir_name, file_name);
   }
   else
   {
-    asprintf(&cmd, "tar -tvf %s/%s", dir_name, file_name);
+    asprintf(&cmd, "tar -tvf '%s/%s'", dir_name, file_name);
   }
 
   // Execute the command and capture its output

--- a/src/inodeinfo.c
+++ b/src/inodeinfo.c
@@ -12,6 +12,26 @@ const char* denied_message[] = {" .__   __.   ______           _______. __    __
                                 " |__| \\__|  \\______/     |_______/     \\______/  (__)",
                                 "                                                     "};
 
+// Returns the printable length of a string (len should be given as a sizeof() operation) at the 
+// current time based on the current window size.
+// If `quarter` == 1, the length is adjusted for a quarter of the screen, else for half.   
+int cap_label_length(unsigned int len, unsigned int quarter, unsigned int margin) {
+  if (quarter == 1) {
+    if (len > ((COLS / 4) - margin)) {
+      return ((COLS / 4) - margin);
+    } else {
+      return len;
+    }
+  } else {
+    if (len > (COLS / 2 - margin)) {
+      return ((COLS / 2) - margin);
+    } else {
+      return len;
+    }
+  }
+
+}
+
 void get_file_info_popup(WINDOW* main_win, const char* path, const char* filename)
 {
   struct stat file_stat;
@@ -134,14 +154,16 @@ void get_file_info(WINDOW* info_win, const char* path, const char* filename)
     return;
   }
 
+  int printable_length = cap_label_length(sizeof(truncated_file_name), 0, 6);
+
   // Truncate the filename if necessary
   if (strlen(filename) > MAX_ITEM_NAME_LENGTH)
   {
-    snprintf(truncated_file_name, sizeof(truncated_file_name), "%.80s...", filename);
+    snprintf(truncated_file_name, printable_length, "%.80s...", filename);
   }
   else
   {
-    snprintf(truncated_file_name, sizeof(truncated_file_name), "%s", filename);
+    snprintf(truncated_file_name, printable_length, "%s", filename);
   }
 
   // Display file information
@@ -264,10 +286,7 @@ void get_file_info(WINDOW* info_win, const char* path, const char* filename)
           {
             // Truncate directory name if necessary
             char truncated_dir_name[MAX_ITEM_NAME_LENGTH + 4]; // +4 for ellipsis and space
-            int printable_length = sizeof(truncated_dir_name);
-            if (sizeof(truncated_dir_name) > ((COLS / 4) - 16)) {
-              printable_length = ((COLS / 4) - 4);
-            }
+            int printable_length = cap_label_length(sizeof(truncated_dir_name), 1, 4);
             if (strlen(entry->d_name) > MAX_ITEM_NAME_LENGTH)
             {
               snprintf(truncated_dir_name, printable_length, "%.40s...", entry->d_name);
@@ -301,10 +320,7 @@ void get_file_info(WINDOW* info_win, const char* path, const char* filename)
           {
             // Truncate directory name if necessary
             char truncated_sub_dir_name[MAX_ITEM_NAME_LENGTH + 4];
-            int printable_length = sizeof(truncated_sub_dir_name);
-            if (sizeof(truncated_sub_dir_name) > ((COLS / 4) - 16)) {
-              printable_length = ((COLS / 4) - 4);
-            }
+            int printable_length = cap_label_length(sizeof(truncated_sub_dir_name), 1, 4);
             if (strlen(entry->d_name) > MAX_ITEM_NAME_LENGTH)
             {
               snprintf(truncated_sub_dir_name, printable_length, "%.40s...",
@@ -327,10 +343,7 @@ void get_file_info(WINDOW* info_win, const char* path, const char* filename)
         {
           // Truncate file name if necessary
           char truncated_file_name[MAX_ITEM_NAME_LENGTH + 4];
-          int printable_length = sizeof(truncated_file_name);
-          if (sizeof(truncated_file_name) > ((COLS / 4) - 16)) {
-            printable_length = ((COLS / 4) - 4);
-          }
+          int printable_length = cap_label_length(sizeof(truncated_file_name), 1, 4);
           if (strlen(entry->d_name) + sub_dir_line > MAX_ITEM_NAME_LENGTH)
           {
             snprintf(truncated_file_name, printable_length, "%.40s...", entry->d_name);

--- a/src/inodeinfo.c
+++ b/src/inodeinfo.c
@@ -15,11 +15,12 @@ const char* denied_message[] = {" .__   __.   ______           _______. __    __
 // Returns the printable length of a string (len should be given as a sizeof() operation) at the 
 // current time based on the current window size.
 // If `quarter` == 1, the length is adjusted for a quarter of the screen, else for half.   
-int cap_label_length(unsigned int len, unsigned int quarter, unsigned int margin) {
-  
+int cap_label_length(unsigned int len, unsigned int quarter, unsigned int margin) 
+{
   // Denominator == 2 if half, == 4 if quarter. 
   int denom = 2 + (2 * quarter);
   
+  // Cap length if too long for screen OR exceeds fixed maximum
   if (len > ((COLS / denom) - margin) || (len > MAX_ITEM_NAME_LENGTH + 4)) {
     return (COLS / denom) - margin;
   } else {

--- a/src/inodeinfo.c
+++ b/src/inodeinfo.c
@@ -16,20 +16,15 @@ const char* denied_message[] = {" .__   __.   ______           _______. __    __
 // current time based on the current window size.
 // If `quarter` == 1, the length is adjusted for a quarter of the screen, else for half.   
 int cap_label_length(unsigned int len, unsigned int quarter, unsigned int margin) {
-  if (quarter == 1) {
-    if (len > ((COLS / 4) - margin)) {
-      return ((COLS / 4) - margin);
-    } else {
-      return len;
-    }
+  
+  // Denominator == 2 if half, == 4 if quarter. 
+  int denom = 2 + (2 * quarter);
+  
+  if (len > ((COLS / denom) - margin) || (len > MAX_ITEM_NAME_LENGTH + 4)) {
+    return (COLS / denom) - margin;
   } else {
-    if (len > (COLS / 2 - margin)) {
-      return ((COLS / 2) - margin);
-    } else {
-      return len;
-    }
+    return len;
   }
-
 }
 
 void get_file_info_popup(WINDOW* main_win, const char* path, const char* filename)
@@ -156,13 +151,11 @@ void get_file_info(WINDOW* info_win, const char* path, const char* filename)
 
   int printable_length = cap_label_length(sizeof(truncated_file_name), 0, 6);
 
-  // Truncate the filename if necessary
-  if (strlen(filename) > MAX_ITEM_NAME_LENGTH)
-  {
-    snprintf(truncated_file_name, printable_length, "%.80s...", filename);
-  }
-  else
-  {
+  // Truncate the filename and add if necessary
+  if (strlen(filename) > printable_length - 3) {
+    snprintf(truncated_file_name, printable_length - 3, "%s", filename);
+    snprintf(truncated_file_name + (printable_length - 6), 4, "...");
+  } else {
     snprintf(truncated_file_name, printable_length, "%s", filename);
   }
 

--- a/src/inodeinfo.c
+++ b/src/inodeinfo.c
@@ -281,12 +281,11 @@ void get_file_info(WINDOW* info_win, const char* path, const char* filename)
             // Truncate directory name if necessary
             char truncated_dir_name[MAX_ITEM_NAME_LENGTH + 4]; // +4 for ellipsis and space
             int printable_length = cap_label_length(sizeof(truncated_dir_name), 1, 4);
-            if (strlen(entry->d_name) > MAX_ITEM_NAME_LENGTH)
-            {
-              snprintf(truncated_dir_name, printable_length, "%.40s...", entry->d_name);
-            }
-            else
-            {
+            
+            if (strlen(entry->d_name) > printable_length - 3) {
+              snprintf(truncated_dir_name, printable_length - 3, "%s", entry->d_name);
+              snprintf(truncated_dir_name + (printable_length - 6), 4, "...");
+            } else {
               snprintf(truncated_dir_name, printable_length, "%s", entry->d_name);
             }
             // Print the directory name
@@ -315,13 +314,10 @@ void get_file_info(WINDOW* info_win, const char* path, const char* filename)
             // Truncate directory name if necessary
             char truncated_sub_dir_name[MAX_ITEM_NAME_LENGTH + 4];
             int printable_length = cap_label_length(sizeof(truncated_sub_dir_name), 1, 4);
-            if (strlen(entry->d_name) > MAX_ITEM_NAME_LENGTH)
-            {
-              snprintf(truncated_sub_dir_name, printable_length, "%.40s...",
-                       entry->d_name);
-            }
-            else
-            {
+            if (strlen(entry->d_name) > printable_length - 3) {
+              snprintf(truncated_sub_dir_name, printable_length - 3, "%s", entry->d_name);
+              snprintf(truncated_sub_dir_name + (printable_length - 6), 4, "...");
+            } else {
               snprintf(truncated_sub_dir_name, printable_length, "%s", entry->d_name);
             }
             wattron(info_win, A_BOLD | COLOR_PAIR(DIR_COLOR_PAIR));
@@ -338,12 +334,10 @@ void get_file_info(WINDOW* info_win, const char* path, const char* filename)
           // Truncate file name if necessary
           char truncated_file_name[MAX_ITEM_NAME_LENGTH + 4];
           int printable_length = cap_label_length(sizeof(truncated_file_name), 1, 4);
-          if (strlen(entry->d_name) + sub_dir_line > MAX_ITEM_NAME_LENGTH)
-          {
-            snprintf(truncated_file_name, printable_length, "%.40s...", entry->d_name);
-          }
-          else
-          {
+          if (strlen(entry->d_name) > printable_length - 3) {
+            snprintf(truncated_file_name, printable_length - 3, "%s", entry->d_name);
+            snprintf(truncated_file_name + (printable_length - 6), 4, "...");
+          } else {
             snprintf(truncated_file_name, printable_length, "%s", entry->d_name);
           }
           wattron(info_win, A_BOLD | COLOR_PAIR(FILE_COLOR_PAIR));

--- a/src/inodeinfo.c
+++ b/src/inodeinfo.c
@@ -264,13 +264,17 @@ void get_file_info(WINDOW* info_win, const char* path, const char* filename)
           {
             // Truncate directory name if necessary
             char truncated_dir_name[MAX_ITEM_NAME_LENGTH + 4]; // +4 for ellipsis and space
+            int printable_length = sizeof(truncated_dir_name);
+            if (sizeof(truncated_dir_name) > ((COLS / 4) - 16)) {
+              printable_length = ((COLS / 4) - 4);
+            }
             if (strlen(entry->d_name) > MAX_ITEM_NAME_LENGTH)
             {
-              snprintf(truncated_dir_name, sizeof(truncated_dir_name), "%.40s...", entry->d_name);
+              snprintf(truncated_dir_name, printable_length, "%.40s...", entry->d_name);
             }
             else
             {
-              snprintf(truncated_dir_name, sizeof(truncated_dir_name), "%s", entry->d_name);
+              snprintf(truncated_dir_name, printable_length, "%s", entry->d_name);
             }
             // Print the directory name
             mvwprintw(info_win, line++, 2, "%s", truncated_dir_name);
@@ -297,14 +301,18 @@ void get_file_info(WINDOW* info_win, const char* path, const char* filename)
           {
             // Truncate directory name if necessary
             char truncated_sub_dir_name[MAX_ITEM_NAME_LENGTH + 4];
+            int printable_length = sizeof(truncated_sub_dir_name);
+            if (sizeof(truncated_sub_dir_name) > ((COLS / 4) - 16)) {
+              printable_length = ((COLS / 4) - 4);
+            }
             if (strlen(entry->d_name) > MAX_ITEM_NAME_LENGTH)
             {
-              snprintf(truncated_sub_dir_name, sizeof(truncated_sub_dir_name), "%.40s...",
+              snprintf(truncated_sub_dir_name, printable_length, "%.40s...",
                        entry->d_name);
             }
             else
             {
-              snprintf(truncated_sub_dir_name, sizeof(truncated_sub_dir_name), "%s", entry->d_name);
+              snprintf(truncated_sub_dir_name, printable_length, "%s", entry->d_name);
             }
             wattron(info_win, A_BOLD | COLOR_PAIR(DIR_COLOR_PAIR));
             mvwprintw(info_win, sub_dir_line++, max_x / 2, "  %s", truncated_sub_dir_name);
@@ -319,13 +327,17 @@ void get_file_info(WINDOW* info_win, const char* path, const char* filename)
         {
           // Truncate file name if necessary
           char truncated_file_name[MAX_ITEM_NAME_LENGTH + 4];
+          int printable_length = sizeof(truncated_file_name);
+          if (sizeof(truncated_file_name) > ((COLS / 4) - 16)) {
+            printable_length = ((COLS / 4) - 4);
+          }
           if (strlen(entry->d_name) + sub_dir_line > MAX_ITEM_NAME_LENGTH)
           {
-            snprintf(truncated_file_name, sizeof(truncated_file_name), "%.40s...", entry->d_name);
+            snprintf(truncated_file_name, printable_length, "%.40s...", entry->d_name);
           }
           else
           {
-            snprintf(truncated_file_name, sizeof(truncated_file_name), "%s", entry->d_name);
+            snprintf(truncated_file_name, printable_length, "%s", entry->d_name);
           }
           wattron(info_win, A_BOLD | COLOR_PAIR(FILE_COLOR_PAIR));
           mvwprintw(info_win, sub_dir_line++, max_x / 2, "  %s", truncated_file_name);


### PR DESCRIPTION
Changelog 2_9_1 reads as follows:

# Change Type:Minor

# Summary of the changes

-> Added a new function cap_label_length to the inodeinfo.h/inodeinfo.c module for determining printable length of labels based on current window width or fixed max length, whichever is
more restrictive.

-> Restricted the length of current directory, parent, and child
inodes, as well as the file name field in the file info window, 
to prevent overrun onto the next line.

-> Add single quotes to the unzip/7z/tar commands to prevent issues with filenames containing spaces in filepreview module.

-> Modified the process of truncating strings and adding ellipses ("...") for the following labels:
    - Filename in selected file info window at top right.
    - Filenames in current dir. in left window.
    - Parent directories at bottom right in info window.
    - Child inodes at bottom right in info window.